### PR TITLE
feat(): XConnector try to leverage generic fabric logic for connectors.

### DIFF
--- a/.codesandbox/templates/next/package.json
+++ b/.codesandbox/templates/next/package.json
@@ -16,6 +16,7 @@
     "aws-sdk": "^2.1632.0",
     "bootstrap": "^5.2.3",
     "browser-image-compression": "^2.0.2",
+    "fabric": "file:../../../../fabric.js",
     "hammerjs": "^2.0.8",
     "i18next": "^23.11.5",
     "i18next-browser-languagedetector": "^8.0.0",

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -11,6 +11,16 @@ import type {
   LayoutBeforeEvent,
   LayoutAfterEvent,
 } from './LayoutManager/types';
+import type {
+  MODIFIED,
+  MODIFY_PATH,
+  MODIFY_POLY,
+  MOVING,
+  RESIZING,
+  ROTATING,
+  SCALING,
+  SKEWING,
+} from './constants';
 
 export type ModifierKey = keyof Pick<
   MouseEvent | PointerEvent | TouchEvent,
@@ -97,38 +107,49 @@ export interface BasicTransformEvent<E extends Event = TPointerEvent>
 }
 
 export type TModificationEvents =
-  | 'moving'
-  | 'scaling'
-  | 'rotating'
-  | 'skewing'
-  | 'resizing'
-  | 'modifyPoly'
-  | 'modifyPath';
+  | typeof MOVING
+  | typeof SCALING
+  | typeof ROTATING
+  | typeof SKEWING
+  | typeof RESIZING
+  | typeof MODIFY_POLY
+  | typeof MODIFY_PATH;
 
 export interface ModifiedEvent<E extends Event = TPointerEvent> {
   e?: E;
-  transform: Transform;
+  transform?: Transform;
   target: FabricObject;
   action?: string;
 }
 
-type ModificationEventsSpec<
-  Prefix extends string = '',
-  Modification = BasicTransformEvent,
-  Modified = ModifiedEvent | never
-> = Record<`${Prefix}${TModificationEvents}`, Modification> &
-  Record<`${Prefix}modified`, Modified>;
+export interface ModifyPathEvent {
+  commandIndex: number;
+  pointIndex: number;
+}
 
-type ObjectModificationEvents = ModificationEventsSpec;
+export type ObjectModificationEvents = {
+  [MOVING]: BasicTransformEvent;
+  [SCALING]: BasicTransformEvent;
+  [ROTATING]: BasicTransformEvent;
+  [SKEWING]: BasicTransformEvent;
+  [RESIZING]: BasicTransformEvent;
+  [MODIFY_POLY]: BasicTransformEvent;
+  [MODIFY_PATH]: BasicTransformEvent & ModifyPathEvent;
+  [MODIFIED]: ModifiedEvent;
+};
 
-type CanvasModificationEvents = ModificationEventsSpec<
-  'object:',
-  BasicTransformEvent & { target: FabricObject },
-  // TODO: this typing makes not possible to use properties from modified event
-  // in object:modified
-  ModifiedEvent | { target: FabricObject }
-> & {
+type CanvasModificationEvents = {
   'before:transform': TEvent & { transform: Transform };
+  'object:moving': BasicTransformEvent & { target: FabricObject };
+  'object:scaling': BasicTransformEvent & { target: FabricObject };
+  'object:rotating': BasicTransformEvent & { target: FabricObject };
+  'object:skewing': BasicTransformEvent & { target: FabricObject };
+  'object:resizing': BasicTransformEvent & { target: FabricObject };
+  'object:modifyPoly': BasicTransformEvent & { target: FabricObject };
+  'object:modifyPath': BasicTransformEvent & {
+    target: FabricObject;
+  } & ModifyPathEvent;
+  'object:modified': ModifiedEvent;
 };
 
 export interface TPointerEventInfo<E extends TPointerEvent = TPointerEvent>

--- a/src/EventTypeDefs.ts
+++ b/src/EventTypeDefs.ts
@@ -102,7 +102,8 @@ export type TModificationEvents =
   | 'rotating'
   | 'skewing'
   | 'resizing'
-  | 'modifyPoly';
+  | 'modifyPoly'
+  | 'modifyPath';
 
 export interface ModifiedEvent<E extends Event = TPointerEvent> {
   e?: E;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,4 +24,22 @@ export const BOTTOM = 'bottom';
 export const RIGHT = 'right';
 export const NONE = 'none';
 
+export const MOVING = 'moving';
+export const SCALING = 'scaling';
+export const ROTATING = 'rotating';
+export const ROTATE = 'rotate';
+export const SKEWING = 'skewing';
+export const RESIZING = 'resizing';
+export const MODIFY_POLY = 'modifyPoly';
+export const MODIFY_PATH = 'modifyPath';
+export const CHANGED = 'changed';
+export const SCALE = 'scale';
+export const SCALE_X = 'scaleX';
+export const SCALE_Y = 'scaleY';
+export const SKEW_X = 'skewX';
+export const SKEW_Y = 'skewY';
+export const FILL = 'fill';
+export const STROKE = 'stroke';
+export const MODIFIED = 'modified';
+
 export const reNewline = /\r?\n/;

--- a/src/controls/controlRendering.ts
+++ b/src/controls/controlRendering.ts
@@ -15,12 +15,14 @@ export type ControlRenderingStyleOverride = Partial<
   >
 >;
 
-export type ControlRenderer = (
+export type ControlRenderer<
+  O extends InteractiveFabricObject = InteractiveFabricObject
+> = (
   ctx: CanvasRenderingContext2D,
   left: number,
   top: number,
   styleOverride: ControlRenderingStyleOverride,
-  fabricObject: InteractiveFabricObject
+  fabricObject: O
 ) => void;
 
 /**

--- a/src/controls/pathControl.ts
+++ b/src/controls/pathControl.ts
@@ -12,13 +12,13 @@ import type {
 import { wrapWithFireEvent } from './wrapWithFireEvent';
 import { sendPointToPlane } from '../util/misc/planeChange';
 import type { TSimpleParseCommandType } from '../util/path/typedefs';
-import { iMatrix, MODIFY_PATH } from '../constants';
+import { iMatrix } from '../constants';
 import type {
   ControlRenderer,
   ControlRenderingStyleOverride,
 } from './controlRendering';
 
-const ACTION_NAME: TModificationEvents = MODIFY_PATH;
+const ACTION_NAME: TModificationEvents = 'modifyPath';
 
 type TTransformAnchor = Transform & {
   pointIndex: number;

--- a/src/controls/pathControl.ts
+++ b/src/controls/pathControl.ts
@@ -12,13 +12,13 @@ import type {
 import { wrapWithFireEvent } from './wrapWithFireEvent';
 import { sendPointToPlane } from '../util/misc/planeChange';
 import type { TSimpleParseCommandType } from '../util/path/typedefs';
-import { iMatrix } from '../constants';
+import { iMatrix, MODIFY_PATH } from '../constants';
 import type {
   ControlRenderer,
   ControlRenderingStyleOverride,
 } from './controlRendering';
 
-const ACTION_NAME: TModificationEvents = 'modifyPoly';
+const ACTION_NAME: TModificationEvents = MODIFY_PATH;
 
 type TTransformAnchor = Transform & {
   pointIndex: number;
@@ -168,7 +168,8 @@ export const createPathActionHandler = (
 ) =>
   wrapWithFireEvent(
     ACTION_NAME,
-    factoryPathActionHandler(commandIndex, pointIndex, PathActionHandler)
+    factoryPathActionHandler(commandIndex, pointIndex, PathActionHandler),
+    { pointIndex, commandIndex }
   );
 
 const indexFromPrevCommand = (previousCommandType: TSimpleParseCommandType) =>
@@ -218,14 +219,14 @@ export function createPathControls(
     }
     switch (commandType) {
       case 'C':
-        controls[`c_${commandIndex}_${commandType}_c1`] = createControl(
+        controls[`c_${commandIndex}_${commandType}_CP_1`] = createControl(
           commandIndex,
           1,
           options,
           commandIndex - 1,
           indexFromPrevCommand(previousCommandType)
         );
-        controls[`c_${commandIndex}_${commandType}_c2`] = createControl(
+        controls[`c_${commandIndex}_${commandType}_CP_2`] = createControl(
           commandIndex,
           3,
           options,
@@ -234,7 +235,7 @@ export function createPathControls(
         );
         break;
       case 'Q':
-        controls[`c_${commandIndex}_${commandType}_c1`] = createControl(
+        controls[`c_${commandIndex}_${commandType}_CP_1`] = createControl(
           commandIndex,
           1,
           options,

--- a/src/controls/pathControl.ts
+++ b/src/controls/pathControl.ts
@@ -19,9 +19,9 @@ const ACTION_NAME: TModificationEvents = 'modifyPath' as const;
 type TTransformAnchor = Transform;
 
 export type PathPointControlStyle = {
-  controlFill: string;
-  controlStroke: string;
-  connectionDashArray: number[];
+  controlFill?: string;
+  controlStroke?: string;
+  connectionDashArray?: number[];
 };
 
 export const calcPathPointPosition = (
@@ -127,6 +127,7 @@ export function pathActionHandler(
       pointIndex,
     });
   }
+  return actionPerformed;
 }
 
 const indexFromPrevCommand = (previousCommandType: TSimpleParseCommandType) =>
@@ -152,6 +153,7 @@ class PathPointControl extends Control {
       ...styleOverride,
       cornerColor: this.controlFill,
       cornerStrokeColor: this.controlStroke,
+      transparentCorners: !this.controlFill,
     };
     super.render(ctx, left, top, overrides, fabricObject);
   }
@@ -216,7 +218,7 @@ const createControl = (
   commandIndexPos: number,
   pointIndexPos: number,
   isControlPoint: boolean,
-  options?: Partial<Control> & {
+  options: Partial<Control> & {
     controlPointStyle?: PathPointControlStyle;
     pointStyle?: PathPointControlStyle;
   },
@@ -232,15 +234,15 @@ const createControl = (
     connectToCommandIndex,
     connectToPointIndex,
     ...options,
-    ...(isControlPoint && options ? options.controlPointStyle : {}),
+    ...(isControlPoint ? options.controlPointStyle : options.pointStyle),
   } as Partial<PathControlPointControl>);
 
 export function createPathControls(
   path: Path,
-  options?: Partial<Control> & {
+  options: Partial<Control> & {
     controlPointStyle?: PathPointControlStyle;
     pointStyle?: PathPointControlStyle;
-  }
+  } = {}
 ): Record<string, Control> {
   const controls = {} as Record<string, Control>;
   let previousCommandType: TSimpleParseCommandType = 'M';

--- a/src/controls/pathControl.ts
+++ b/src/controls/pathControl.ts
@@ -1,4 +1,4 @@
-import { Point, ZERO } from '../Point';
+import { Point } from '../Point';
 import { Control } from './Control';
 import type { TMat2D } from '../typedefs';
 import type { Path } from '../shapes/Path';
@@ -7,118 +7,95 @@ import type {
   TModificationEvents,
   TPointerEvent,
   Transform,
-  TransformActionHandler,
 } from '../EventTypeDefs';
-import { wrapWithFireEvent } from './wrapWithFireEvent';
 import { sendPointToPlane } from '../util/misc/planeChange';
 import type { TSimpleParseCommandType } from '../util/path/typedefs';
-import { iMatrix } from '../constants';
-import type {
-  ControlRenderer,
-  ControlRenderingStyleOverride,
-} from './controlRendering';
+import type { ControlRenderingStyleOverride } from './controlRendering';
+import { fireEvent } from './fireEvent';
+import { commonEventInfo } from './util';
 
-const ACTION_NAME: TModificationEvents = 'modifyPath';
+const ACTION_NAME: TModificationEvents = 'modifyPath' as const;
 
-type TTransformAnchor = Transform & {
-  pointIndex: number;
-  commandIndex: number;
+type TTransformAnchor = Transform;
+
+export type PathPointControlStyle = {
+  controlFill: string;
+  controlStroke: string;
+  connectionDashArray: number[];
 };
 
-export function wrapRenderWithConnection(
+export const calcPathPointPosition = (
+  pathObject: Path,
   commandIndex: number,
-  pointIndex: number,
-  isControlPoint: boolean,
-  options?: Partial<Control> & {
-    cpOverrides?: ControlRenderingStyleOverride;
-    pointOverrides?: ControlRenderingStyleOverride;
-  },
-  commandIndexPrevious?: number,
-  pointIndexPrevious?: number
-): ControlRenderer<Path> {
-  return function (
-    this: Control,
-    ctx: CanvasRenderingContext2D,
-    left: number,
-    top: number,
-    styleOverride: ControlRenderingStyleOverride | undefined,
-    fabricObject: Path
-  ) {
-    console.log('rendering', {
-      isControlPoint,
-      commandIndex,
-      pointIndex,
-      commandIndexPrevious,
-      pointIndexPrevious,
-      options,
-    });
-    const point = createPathPositionHandler(commandIndex, pointIndex)(
-      ZERO,
-      iMatrix,
-      fabricObject
-    );
-    if (isControlPoint) {
-      ctx.save();
-      if (options?.cpOverrides?.cornerStrokeColor) {
-        ctx.strokeStyle = options?.cpOverrides?.cornerStrokeColor;
-      }
-      if (options?.cpOverrides?.cornerDashArray) {
-        ctx.setLineDash(options?.cpOverrides?.cornerDashArray);
-      }
-      if (commandIndexPrevious && pointIndexPrevious) {
-        const point2 = createPathPositionHandler(
-          commandIndexPrevious,
-          pointIndexPrevious
-        )(ZERO, iMatrix, fabricObject);
-        ctx.moveTo(point2.x, point2.y);
-        ctx.lineTo(left, top);
-      } else {
-        ctx.moveTo(left, top);
-      }
-      ctx.lineTo(point.x, point.y);
-      ctx.stroke();
-      if (options?.cpOverrides?.cornerColor) {
-        styleOverride = {
-          ...styleOverride,
-          cornerColor: options.cpOverrides.cornerColor,
-          cornerStrokeColor: options.cpOverrides.cornerStrokeColor,
-        };
-      }
-      ctx.restore();
-    }
-    return Control.prototype.render.call(
-      this,
-      ctx,
-      left,
-      top,
-      styleOverride,
-      fabricObject
-    );
-  };
-}
+  pointIndex: number
+) => {
+  const { path, pathOffset } = pathObject;
+  const command = path[commandIndex];
+  return new Point(
+    (command[pointIndex] as number) - pathOffset.x,
+    (command[pointIndex + 1] as number) - pathOffset.y
+  ).transform(
+    multiplyTransformMatrices(
+      pathObject.getViewportTransform(),
+      pathObject.calcTransformMatrix()
+    )
+  );
+};
+
+export const movePathPoint = (
+  pathObject: Path,
+  x: number,
+  y: number,
+  commandIndex: number,
+  pointIndex: number
+) => {
+  const { path, pathOffset } = pathObject;
+
+  const anchorCommand =
+    path[(commandIndex > 0 ? commandIndex : path.length) - 1];
+  const anchorPoint = new Point(
+    anchorCommand[pointIndex] as number,
+    anchorCommand[pointIndex + 1] as number
+  );
+
+  const anchorPointInParentPlane = anchorPoint
+    .subtract(pathOffset)
+    .transform(pathObject.calcOwnMatrix());
+
+  const mouseLocalPosition = sendPointToPlane(
+    new Point(x, y),
+    undefined,
+    pathObject.calcOwnMatrix()
+  );
+
+  path[commandIndex][pointIndex] = mouseLocalPosition.x + pathOffset.x;
+  path[commandIndex][pointIndex + 1] = mouseLocalPosition.y + pathOffset.y;
+  pathObject.setDimensions();
+
+  const newAnchorPointInParentPlane = anchorPoint
+    .subtract(pathObject.pathOffset)
+    .transform(pathObject.calcOwnMatrix());
+
+  const diff = newAnchorPointInParentPlane.subtract(anchorPointInParentPlane);
+  pathObject.left -= diff.x;
+  pathObject.top -= diff.y;
+
+  return true;
+};
 
 /**
  * This function locates the controls.
  * It'll be used both for drawing and for interaction.
  */
-export const createPathPositionHandler = (
-  commandIndex: number,
-  pointIndex: number
-) => {
-  return function (dim: Point, finalMatrix: TMat2D, pathObject: Path) {
-    const { path, pathOffset } = pathObject;
-    const command = path[commandIndex];
-    return new Point(
-      (command[pointIndex] as number) - pathOffset.x,
-      (command[pointIndex + 1] as number) - pathOffset.y
-    ).transform(
-      multiplyTransformMatrices(
-        pathObject.getViewportTransform(),
-        pathObject.calcTransformMatrix()
-      )
-    );
-  };
-};
+function pathPositionHandler(
+  this: PathPointControl,
+  dim: Point,
+  finalMatrix: TMat2D,
+  pathObject: Path
+) {
+  const { commandIndex, pointIndex } = this;
+  return calcPathPointPosition(pathObject, commandIndex, pointIndex);
+}
 
 /**
  * This function defines what the control does.
@@ -127,122 +104,142 @@ export const createPathPositionHandler = (
  * and the current position in canvas coordinate `transform.target` is a reference to the
  * current object being transformed.
  */
-export const PathActionHandler = (
+export function pathActionHandler(
+  this: PathPointControl,
   eventData: TPointerEvent,
   transform: TTransformAnchor,
   x: number,
   y: number
-) => {
-  const { target, pointIndex, commandIndex } = transform;
-  const { path, pathOffset } = target as Path;
-  const mouseLocalPosition = sendPointToPlane(
-    new Point(x, y),
-    undefined,
-    target.calcOwnMatrix()
+) {
+  const { target } = transform;
+  const { commandIndex, pointIndex } = this;
+  const actionPerformed = movePathPoint(
+    target as Path,
+    x,
+    y,
+    commandIndex,
+    pointIndex
   );
-
-  path[commandIndex][pointIndex] = mouseLocalPosition.x + pathOffset.x;
-  path[commandIndex][pointIndex + 1] = mouseLocalPosition.y + pathOffset.y;
-  (target as Path).setDimensions();
-
-  return true;
-};
-
-/**
- * Keep the path in the same position when we change its `width`/`height`/`top`/`left`.
- */
-export const factoryPathActionHandler = (
-  commandIndex: number,
-  pointIndex: number,
-  fn: TransformActionHandler<TTransformAnchor>
-) => {
-  return function (
-    eventData: TPointerEvent,
-    transform: Transform,
-    x: number,
-    y: number
-  ) {
-    const { target } = transform;
-    const { path, pathOffset } = target as Path,
-      anchorCommand = path[(commandIndex > 0 ? commandIndex : path.length) - 1],
-      anchorPoint = new Point(
-        anchorCommand[pointIndex] as number,
-        anchorCommand[pointIndex + 1] as number
-      ),
-      anchorPointInParentPlane = anchorPoint
-        .subtract(pathOffset)
-        .transform(target.calcOwnMatrix()),
-      // fn mutates target, target.path and target.pathOffset
-      actionPerformed = fn(
-        eventData,
-        { ...transform, pointIndex, commandIndex },
-        x,
-        y
-      );
-
-    const newAnchorPointInParentPlane = anchorPoint
-      .subtract((target as Path).pathOffset)
-      .transform(target.calcOwnMatrix());
-
-    const diff = newAnchorPointInParentPlane.subtract(anchorPointInParentPlane);
-    target.left -= diff.x;
-    target.top -= diff.y;
-
-    return actionPerformed;
-  };
-};
-
-export const createPathActionHandler = (
-  commandIndex: number,
-  pointIndex: number
-) =>
-  wrapWithFireEvent(
-    ACTION_NAME,
-    factoryPathActionHandler(commandIndex, pointIndex, PathActionHandler),
-    { pointIndex, commandIndex }
-  );
+  if (actionPerformed) {
+    fireEvent(this.actionName as TModificationEvents, {
+      ...commonEventInfo(eventData, transform, x, y),
+      commandIndex,
+      pointIndex,
+    });
+  }
+}
 
 const indexFromPrevCommand = (previousCommandType: TSimpleParseCommandType) =>
   previousCommandType === 'C' ? 5 : previousCommandType === 'Q' ? 3 : 1;
+
+class PathPointControl extends Control {
+  declare commandIndex: number;
+  declare pointIndex: number;
+  declare controlFill: string;
+  declare controlStroke: string;
+  constructor(options?: Partial<PathPointControl>) {
+    super(options);
+  }
+
+  render(
+    ctx: CanvasRenderingContext2D,
+    left: number,
+    top: number,
+    styleOverride: ControlRenderingStyleOverride | undefined,
+    fabricObject: Path
+  ) {
+    const overrides: ControlRenderingStyleOverride = {
+      ...styleOverride,
+      cornerColor: this.controlFill,
+      cornerStrokeColor: this.controlStroke,
+    };
+    super.render(ctx, left, top, overrides, fabricObject);
+  }
+}
+
+class PathControlPointControl extends PathPointControl {
+  declare connectionDashArray?: number[];
+  declare connectToCommandIndex: number;
+  declare connectToPointIndex: number;
+  constructor(options?: Partial<PathControlPointControl>) {
+    super(options);
+  }
+
+  render(
+    this: PathControlPointControl,
+    ctx: CanvasRenderingContext2D,
+    left: number,
+    top: number,
+    styleOverride: ControlRenderingStyleOverride | undefined,
+    fabricObject: Path
+  ) {
+    const { path } = fabricObject;
+    const {
+      commandIndex,
+      pointIndex,
+      connectToCommandIndex,
+      connectToPointIndex,
+    } = this;
+    ctx.save();
+    ctx.strokeStyle = this.controlStroke;
+    if (this.connectionDashArray) {
+      ctx.setLineDash(this.connectionDashArray);
+    }
+    const [commandType] = path[commandIndex];
+    const point = calcPathPointPosition(
+      fabricObject,
+      connectToCommandIndex,
+      connectToPointIndex
+    );
+
+    if (commandType === 'Q') {
+      // one control point connects to 2 points
+      const point2 = calcPathPointPosition(
+        fabricObject,
+        commandIndex,
+        pointIndex + 2
+      );
+      ctx.moveTo(point2.x, point2.y);
+      ctx.lineTo(left, top);
+    } else {
+      ctx.moveTo(left, top);
+    }
+    ctx.lineTo(point.x, point.y);
+    ctx.stroke();
+    ctx.restore();
+
+    super.render(ctx, left, top, styleOverride, fabricObject);
+  }
+}
 
 const createControl = (
   commandIndexPos: number,
   pointIndexPos: number,
   isControlPoint: boolean,
   options?: Partial<Control> & {
-    cpOverrides?: ControlRenderingStyleOverride;
-    pointOverrides?: ControlRenderingStyleOverride;
+    controlPointStyle?: PathPointControlStyle;
+    pointStyle?: PathPointControlStyle;
   },
-  commandIndexConnect?: number,
-  pointIndexConnect?: number,
-  commandIndexConnect2?: number,
-  pointIndexConnect2?: number
+  connectToCommandIndex?: number,
+  connectToPointIndex?: number
 ) =>
-  new Control({
+  new (isControlPoint ? PathControlPointControl : PathPointControl)({
+    commandIndex: commandIndexPos,
+    pointIndex: pointIndexPos,
     actionName: ACTION_NAME,
-    positionHandler: createPathPositionHandler(commandIndexPos, pointIndexPos),
-    actionHandler: createPathActionHandler(commandIndexPos, pointIndexPos),
-    ...(commandIndexConnect && pointIndexConnect
-      ? {
-          render: wrapRenderWithConnection(
-            commandIndexConnect,
-            pointIndexConnect,
-            isControlPoint,
-            options,
-            commandIndexConnect2,
-            pointIndexConnect2
-          ),
-        }
-      : {}),
+    positionHandler: pathPositionHandler,
+    actionHandler: pathActionHandler,
+    connectToCommandIndex,
+    connectToPointIndex,
     ...options,
-    isControlPoint,
-  });
+    ...(isControlPoint && options ? options.controlPointStyle : {}),
+  } as Partial<PathControlPointControl>);
 
 export function createPathControls(
   path: Path,
   options?: Partial<Control> & {
-    cpOverrides?: ControlRenderingStyleOverride;
-    pointOverrides?: ControlRenderingStyleOverride;
+    controlPointStyle?: PathPointControlStyle;
+    pointStyle?: PathPointControlStyle;
   }
 ): Record<string, Control> {
   const controls = {} as Record<string, Control>;
@@ -260,7 +257,7 @@ export function createPathControls(
     }
     switch (commandType) {
       case 'C':
-        controls[`c_${commandIndex}_${commandType}_CP_1`] = createControl(
+        controls[`c_${commandIndex}_C_CP_1`] = createControl(
           commandIndex,
           1,
           true,
@@ -268,7 +265,7 @@ export function createPathControls(
           commandIndex - 1,
           indexFromPrevCommand(previousCommandType)
         );
-        controls[`c_${commandIndex}_${commandType}_CP_2`] = createControl(
+        controls[`c_${commandIndex}_C_CP_2`] = createControl(
           commandIndex,
           3,
           true,
@@ -278,15 +275,13 @@ export function createPathControls(
         );
         break;
       case 'Q':
-        controls[`c_${commandIndex}_${commandType}_CP_1`] = createControl(
+        controls[`c_${commandIndex}_Q_CP_1`] = createControl(
           commandIndex,
           1,
           true,
           options,
           commandIndex,
-          3,
-          commandIndex - 1,
-          indexFromPrevCommand(previousCommandType)
+          3
         );
         break;
     }

--- a/src/controls/pathControl.ts
+++ b/src/controls/pathControl.ts
@@ -1,0 +1,251 @@
+import { Point, ZERO } from '../Point';
+import { Control } from './Control';
+import type { TMat2D } from '../typedefs';
+import type { Path } from '../shapes/Path';
+import { multiplyTransformMatrices } from '../util/misc/matrix';
+import type {
+  TModificationEvents,
+  TPointerEvent,
+  Transform,
+  TransformActionHandler,
+} from '../EventTypeDefs';
+import { wrapWithFireEvent } from './wrapWithFireEvent';
+import { sendPointToPlane } from '../util/misc/planeChange';
+import type { TSimpleParseCommandType } from '../util/path/typedefs';
+import { iMatrix } from '../constants';
+import type {
+  ControlRenderer,
+  ControlRenderingStyleOverride,
+} from './controlRendering';
+
+const ACTION_NAME: TModificationEvents = 'modifyPoly';
+
+type TTransformAnchor = Transform & {
+  pointIndex: number;
+  commandIndex: number;
+};
+
+export function wrapRenderWithConnection(
+  commandIndex: number,
+  pointIndex: number,
+  commandIndexPrevious?: number,
+  pointIndexPrevious?: number
+): ControlRenderer<Path> {
+  return function (
+    this: Control,
+    ctx: CanvasRenderingContext2D,
+    left: number,
+    top: number,
+    styleOverride: ControlRenderingStyleOverride | undefined,
+    fabricObject: Path
+  ) {
+    const point = createPathPositionHandler(commandIndex, pointIndex)(
+      ZERO,
+      iMatrix,
+      fabricObject
+    );
+    if (commandIndexPrevious && pointIndexPrevious) {
+      const point2 = createPathPositionHandler(
+        commandIndexPrevious,
+        pointIndexPrevious
+      )(ZERO, iMatrix, fabricObject);
+      ctx.moveTo(point2.x, point2.y);
+      ctx.lineTo(left, top);
+    } else {
+      ctx.moveTo(left, top);
+    }
+    ctx.lineTo(point.x, point.y);
+    ctx.stroke();
+    return Control.prototype.render.call(
+      this,
+      ctx,
+      left,
+      top,
+      styleOverride,
+      fabricObject
+    );
+  };
+}
+
+/**
+ * This function locates the controls.
+ * It'll be used both for drawing and for interaction.
+ */
+export const createPathPositionHandler = (
+  commandIndex: number,
+  pointIndex: number
+) => {
+  return function (dim: Point, finalMatrix: TMat2D, pathObject: Path) {
+    const { path, pathOffset } = pathObject;
+    const command = path[commandIndex];
+    return new Point(
+      (command[pointIndex] as number) - pathOffset.x,
+      (command[pointIndex + 1] as number) - pathOffset.y
+    ).transform(
+      multiplyTransformMatrices(
+        pathObject.getViewportTransform(),
+        pathObject.calcTransformMatrix()
+      )
+    );
+  };
+};
+
+/**
+ * This function defines what the control does.
+ * It'll be called on every mouse move after a control has been clicked and is being dragged.
+ * The function receives as argument the mouse event, the current transform object
+ * and the current position in canvas coordinate `transform.target` is a reference to the
+ * current object being transformed.
+ */
+export const PathActionHandler = (
+  eventData: TPointerEvent,
+  transform: TTransformAnchor,
+  x: number,
+  y: number
+) => {
+  const { target, pointIndex, commandIndex } = transform;
+  const { path, pathOffset } = target as Path;
+  const mouseLocalPosition = sendPointToPlane(
+    new Point(x, y),
+    undefined,
+    target.calcOwnMatrix()
+  );
+
+  path[commandIndex][pointIndex] = mouseLocalPosition.x + pathOffset.x;
+  path[commandIndex][pointIndex + 1] = mouseLocalPosition.y + pathOffset.y;
+  (target as Path).setDimensions();
+
+  return true;
+};
+
+/**
+ * Keep the path in the same position when we change its `width`/`height`/`top`/`left`.
+ */
+export const factoryPathActionHandler = (
+  commandIndex: number,
+  pointIndex: number,
+  fn: TransformActionHandler<TTransformAnchor>
+) => {
+  return function (
+    eventData: TPointerEvent,
+    transform: Transform,
+    x: number,
+    y: number
+  ) {
+    const { target } = transform;
+    const { path, pathOffset } = target as Path,
+      anchorCommand = path[(commandIndex > 0 ? commandIndex : path.length) - 1],
+      anchorPoint = new Point(
+        anchorCommand[pointIndex] as number,
+        anchorCommand[pointIndex + 1] as number
+      ),
+      anchorPointInParentPlane = anchorPoint
+        .subtract(pathOffset)
+        .transform(target.calcOwnMatrix()),
+      // fn mutates target, target.path and target.pathOffset
+      actionPerformed = fn(
+        eventData,
+        { ...transform, pointIndex, commandIndex },
+        x,
+        y
+      );
+
+    const newAnchorPointInParentPlane = anchorPoint
+      .subtract((target as Path).pathOffset)
+      .transform(target.calcOwnMatrix());
+
+    const diff = newAnchorPointInParentPlane.subtract(anchorPointInParentPlane);
+    target.left -= diff.x;
+    target.top -= diff.y;
+
+    return actionPerformed;
+  };
+};
+
+export const createPathActionHandler = (
+  commandIndex: number,
+  pointIndex: number
+) =>
+  wrapWithFireEvent(
+    ACTION_NAME,
+    factoryPathActionHandler(commandIndex, pointIndex, PathActionHandler)
+  );
+
+const indexFromPrevCommand = (previousCommandType: TSimpleParseCommandType) =>
+  previousCommandType === 'C' ? 5 : previousCommandType === 'Q' ? 3 : 1;
+
+const createControl = (
+  commandIndexPos: number,
+  pointIndexPos: number,
+  options?: Partial<Control>,
+  commandIndexConnect?: number,
+  pointIndexConnect?: number,
+  commandIndexConnect2?: number,
+  pointIndexConnect2?: number
+) =>
+  new Control({
+    actionName: ACTION_NAME,
+    positionHandler: createPathPositionHandler(commandIndexPos, pointIndexPos),
+    actionHandler: createPathActionHandler(commandIndexPos, pointIndexPos),
+    ...(commandIndexConnect && pointIndexConnect
+      ? {
+          render: wrapRenderWithConnection(
+            commandIndexConnect,
+            pointIndexConnect,
+            commandIndexConnect2,
+            pointIndexConnect2
+          ),
+        }
+      : {}),
+    ...options,
+  });
+
+export function createPathControls(
+  path: Path,
+  options?: Partial<Control>
+): Record<string, Control> {
+  const controls = {} as Record<string, Control>;
+  let previousCommandType: TSimpleParseCommandType = 'M';
+  path.path.forEach((command, commandIndex) => {
+    const commandType = command[0];
+
+    if (commandType !== 'Z') {
+      controls[`c_${commandIndex}_${commandType}`] = createControl(
+        commandIndex,
+        command.length - 2,
+        options
+      );
+    }
+    switch (commandType) {
+      case 'C':
+        controls[`c_${commandIndex}_${commandType}_c1`] = createControl(
+          commandIndex,
+          1,
+          options,
+          commandIndex - 1,
+          indexFromPrevCommand(previousCommandType)
+        );
+        controls[`c_${commandIndex}_${commandType}_c2`] = createControl(
+          commandIndex,
+          3,
+          options,
+          commandIndex,
+          5
+        );
+        break;
+      case 'Q':
+        controls[`c_${commandIndex}_${commandType}_c1`] = createControl(
+          commandIndex,
+          1,
+          options,
+          commandIndex,
+          3,
+          commandIndex - 1,
+          indexFromPrevCommand(previousCommandType)
+        );
+        break;
+    }
+    previousCommandType = commandType;
+  });
+  return controls;
+}

--- a/src/controls/wrapWithFireEvent.ts
+++ b/src/controls/wrapWithFireEvent.ts
@@ -8,17 +8,26 @@ import { commonEventInfo } from './util';
 
 /**
  * Wrap an action handler with firing an event if the action is performed
- * @param {Function} actionHandler the function to wrap
- * @return {Function} a function with an action handler signature
+ * @param {TModificationEvents} eventName the event we want to fire
+ * @param {TransformActionHandler<T>} actionHandler the function to wrap
+ * @param {object} extraEventInfo extra information to pas to the event handler
+ * @return {TransformActionHandler<T>} a function with an action handler signature
  */
-export const wrapWithFireEvent = <T extends Transform>(
+export const wrapWithFireEvent = <
+  T extends Transform,
+  P extends object = Record<string, never>
+>(
   eventName: TModificationEvents,
-  actionHandler: TransformActionHandler<T>
+  actionHandler: TransformActionHandler<T>,
+  extraEventInfo?: P
 ) => {
   return ((eventData, transform, x, y) => {
     const actionPerformed = actionHandler(eventData, transform, x, y);
     if (actionPerformed) {
-      fireEvent(eventName, commonEventInfo(eventData, transform, x, y));
+      fireEvent(eventName, {
+        ...commonEventInfo(eventData, transform, x, y),
+        ...extraEventInfo,
+      });
     }
     return actionPerformed;
   }) as TransformActionHandler<T>;

--- a/src/shapes/canvasx/XConnector.ts
+++ b/src/shapes/canvasx/XConnector.ts
@@ -5,7 +5,6 @@ import {
   TSimpleParsedCommand,
 } from '../../util';
 import { Point, XY } from '../../Point';
-import { createObjectDefaultControls } from '../../controls/commonControls';
 import { FabricObject } from '../Object/Object';
 import { Transform } from '../../EventTypeDefs';
 import { classRegistry } from '../../ClassRegistry';
@@ -56,6 +55,10 @@ class XConnector extends Path {
   ) {
     const path = getPath(fromPoint, toPoint, control1, control2);
     super(path, options);
+    this.cornerColor = 'white';
+    this.cornerStyle = 'circle';
+    this.transparentCorners = false;
+    this.cornerStrokeColor = 'gray';
     this.type = 'XConnector';
     this.objectCaching = false;
     this.pathType = options.pathType || 'curvePath';
@@ -65,11 +68,15 @@ class XConnector extends Path {
     this.style = style;
     this.calcStartEndPath();
     this.controls = {
-      ...createObjectDefaultControls,
       ...createPathControls(this, {
         mouseDownHandler: this._mouseDownControl.bind(this),
         mouseUpHandler: this._mouseUpControl.bind(this),
         cursorStyle: 'crosshair',
+        cpOverrides: {
+          cornerColor: 'blue',
+          cornerDashArray: [5, 5],
+          cornerStrokeColor: 'gray',
+        },
       }),
     };
     this.on('modifyPath', function (this: XConnector, evtOpt) {
@@ -300,58 +307,6 @@ class XConnector extends Path {
         },
       });
     }
-  }
-
-  _renderControl(
-    controlType: string,
-    ctx: any,
-    left: number,
-    top: number,
-    styleOverride: any,
-    fabricObject: FabricObject
-  ) {
-    let color = 'white';
-    if (controlType === 'control1' || controlType === 'control2') {
-      color = 'blue';
-    }
-
-    const drawDottedLine = (targetControl: string) => {
-      const point = TransformPointFromObjectToCanvas2(
-        fabricObject,
-        new Point({
-          x: this.controls[targetControl].offsetX,
-          y: this.controls[targetControl].offsetY,
-        })
-      );
-
-      ctx.save();
-      ctx.strokeStyle = 'gray';
-      ctx.setLineDash([5, 5]); // Set the line dash pattern
-      ctx.beginPath();
-      ctx.moveTo(left, top);
-      ctx.lineTo(point.x, point.y);
-      ctx.closePath();
-      ctx.stroke();
-      ctx.restore();
-    };
-
-    if (controlType === 'control1') {
-      drawDottedLine('start');
-    }
-
-    if (controlType === 'control2') {
-      drawDottedLine('end');
-    }
-
-    ctx.save();
-    ctx.fillStyle = color;
-    ctx.strokeStyle = 'gray';
-    ctx.beginPath();
-    ctx.arc(left, top, 5, 0, Math.PI * 2, false);
-    ctx.closePath();
-    ctx.fill();
-    ctx.stroke();
-    ctx.restore();
   }
 }
 

--- a/src/shapes/canvasx/XConnector.ts
+++ b/src/shapes/canvasx/XConnector.ts
@@ -75,8 +75,6 @@ class XConnector extends Path {
         mouseUpHandler: this._mouseUpControl.bind(this),
         cursorStyle: 'crosshair',
       }),
-      //   actionHandler: this.dragActionHandler.bind(this, 'control2'),
-      //   render: this._renderControl.bind(this, 'control2'),
     };
     this.on('modifyPath', function (this: XConnector, evtOpt) {
       this.calcStartEndPath();

--- a/src/shapes/canvasx/XConnector.ts
+++ b/src/shapes/canvasx/XConnector.ts
@@ -75,6 +75,12 @@ class XConnector extends Path {
     };
     this.on('modifyPath', function (this: XConnector, evtOpt) {
       this.calcStartEndPath();
+      const { commandIndex, pointIndex } = evtOpt;
+      // commandIndex === 0 is always start,
+      // all the commandIndex === 1 are control points apart the 5
+      if (commandIndex === 1 && pointIndex !== 5) {
+        return;
+      }
       this.dragActionEventHandler(evtOpt.commandIndex, evtOpt.pointIndex);
     });
   }
@@ -263,6 +269,8 @@ class XConnector extends Path {
     // Andrea, followup: currentDockingObject.hoveringControl relies on a mousemove event that gets added
     // and removed when we start the connector drag.
     // this logic should be resolved inside the connector.
+
+    // early return if we are dragging a control point
 
     if (
       currentDockingObject &&

--- a/src/shapes/canvasx/XConnector.ts
+++ b/src/shapes/canvasx/XConnector.ts
@@ -30,12 +30,6 @@ const getPath = (
 class XConnector extends Path {
   static type = 'XConnector';
   objType = 'Xconnector';
-
-  fromPoint: XY | null;
-  toPoint: XY | null;
-  control1: XY | null;
-  control2: XY | null;
-  offset: XY;
   style: any;
   prevLeft: number;
   prevTop: number;
@@ -296,8 +290,6 @@ class XConnector extends Path {
       switch (commandIndex) {
         // command 0 means start of the path
         case 0:
-          target.set({ control1: relevantControlPoint });
-
           if (target.fromId) {
             const fromObject = target.canvas?.findById(target.fromId);
             if (fromObject) {
@@ -311,8 +303,6 @@ class XConnector extends Path {
 
           break;
         case this.path.length - 1:
-          target.set({ control2: relevantControlPoint });
-
           if (target.toId) {
             const toObject = target.canvas?.findById(target.toId);
             if (toObject) {

--- a/src/shapes/canvasx/XConnector.ts
+++ b/src/shapes/canvasx/XConnector.ts
@@ -1,6 +1,6 @@
 import { Path } from '../Path';
 import { Control } from '../../controls/Control';
-import { invertTransform, multiplyTransformMatrices } from '../../util';
+import { multiplyTransformMatrices, sendPointToPlane } from '../../util';
 import { Point, XY } from '../../Point';
 import { TMat2D } from '../../typedefs';
 import { InteractiveFabricObject } from '../Object/InteractiveObject';
@@ -8,6 +8,8 @@ import { createObjectDefaultControls } from '../../controls/commonControls';
 import { FabricObject } from '../Object/Object';
 import { Transform } from '../../EventTypeDefs';
 import { classRegistry } from '../../ClassRegistry';
+import { iMatrix } from '../../constants';
+import { createPathControls } from '../../controls/pathControl';
 
 const getPath = (
   fromPoint: XY,
@@ -47,66 +49,66 @@ const getPath = (
   let startPath = '';
   let endPath = '';
 
-  if (pathArrowTip === 'start' || pathArrowTip === 'both') {
-    const startArrowSize = 10; // Adjust the size of the start arrow tip
-    let startAngle;
+  // if (pathArrowTip === 'start' || pathArrowTip === 'both') {
+  //   const startArrowSize = 10; // Adjust the size of the start arrow tip
+  //   let startAngle;
 
-    if (pathType === 'straightPath')
-      startAngle =
-        Math.atan2(fromPoint.y - toPoint.y, fromPoint.x - toPoint.x) + Math.PI;
-    else
-      startAngle = Math.atan2(
-        control1.y - fromPoint.y,
-        control1.x - fromPoint.x
-      );
+  //   if (pathType === 'straightPath')
+  //     startAngle =
+  //       Math.atan2(fromPoint.y - toPoint.y, fromPoint.x - toPoint.x) + Math.PI;
+  //   else
+  //     startAngle = Math.atan2(
+  //       control1.y - fromPoint.y,
+  //       control1.x - fromPoint.x
+  //     );
 
-    const startArrow1X =
-      fromPoint.x +
-      offsetX +
-      startArrowSize * Math.cos(startAngle + Math.PI / 6);
-    const startArrow1Y =
-      fromPoint.y +
-      offsetY +
-      startArrowSize * Math.sin(startAngle + Math.PI / 6);
-    const startArrow2X =
-      fromPoint.x +
-      offsetX +
-      startArrowSize * Math.cos(startAngle - Math.PI / 6);
-    const startArrow2Y =
-      fromPoint.y +
-      offsetY +
-      startArrowSize * Math.sin(startAngle - Math.PI / 6);
+  //   const startArrow1X =
+  //     fromPoint.x +
+  //     offsetX +
+  //     startArrowSize * Math.cos(startAngle + Math.PI / 6);
+  //   const startArrow1Y =
+  //     fromPoint.y +
+  //     offsetY +
+  //     startArrowSize * Math.sin(startAngle + Math.PI / 6);
+  //   const startArrow2X =
+  //     fromPoint.x +
+  //     offsetX +
+  //     startArrowSize * Math.cos(startAngle - Math.PI / 6);
+  //   const startArrow2Y =
+  //     fromPoint.y +
+  //     offsetY +
+  //     startArrowSize * Math.sin(startAngle - Math.PI / 6);
 
-    startPath = `M ${startArrow1X} ${startArrow1Y} L ${fromPoint.x + offsetX} ${
-      fromPoint.y + offsetY
-    } L ${startArrow2X} ${startArrow2Y}`;
-  }
+  //   startPath = `M ${startArrow1X} ${startArrow1Y} L ${fromPoint.x + offsetX} ${
+  //     fromPoint.y + offsetY
+  //   } L ${startArrow2X} ${startArrow2Y}`;
+  // }
 
-  if (pathArrowTip === 'end' || pathArrowTip === 'both') {
-    const endArrowSize = 10; // Adjust the size of the end arrow tip
-    let endAngle;
-    if (pathType === 'straightPath') {
-      endAngle = Math.atan2(toPoint.y - fromPoint.y, toPoint.x - fromPoint.x);
-    } else {
-      endAngle = Math.atan2(toPoint.y - control2.y, toPoint.x - control2.x);
-    }
+  // if (pathArrowTip === 'end' || pathArrowTip === 'both') {
+  //   const endArrowSize = 10; // Adjust the size of the end arrow tip
+  //   let endAngle;
+  //   if (pathType === 'straightPath') {
+  //     endAngle = Math.atan2(toPoint.y - fromPoint.y, toPoint.x - fromPoint.x);
+  //   } else {
+  //     endAngle = Math.atan2(toPoint.y - control2.y, toPoint.x - control2.x);
+  //   }
 
-    const endArrow1X =
-      toPoint.x + offsetX - endArrowSize * Math.cos(endAngle - Math.PI / 6);
-    const endArrow1Y =
-      toPoint.y + offsetY - endArrowSize * Math.sin(endAngle - Math.PI / 6);
-    const endArrow2X =
-      toPoint.x + offsetX - endArrowSize * Math.cos(endAngle + Math.PI / 6);
-    const endArrow2Y =
-      toPoint.y + offsetY - endArrowSize * Math.sin(endAngle + Math.PI / 6);
+  //   const endArrow1X =
+  //     toPoint.x + offsetX - endArrowSize * Math.cos(endAngle - Math.PI / 6);
+  //   const endArrow1Y =
+  //     toPoint.y + offsetY - endArrowSize * Math.sin(endAngle - Math.PI / 6);
+  //   const endArrow2X =
+  //     toPoint.x + offsetX - endArrowSize * Math.cos(endAngle + Math.PI / 6);
+  //   const endArrow2Y =
+  //     toPoint.y + offsetY - endArrowSize * Math.sin(endAngle + Math.PI / 6);
 
-    endPath = `M ${endArrow1X} ${endArrow1Y} L ${toPoint.x + offsetX} ${
-      toPoint.y + offsetY
-    } L ${endArrow2X} ${endArrow2Y}`;
-  }
+  //   endPath = `M ${endArrow1X} ${endArrow1Y} L ${toPoint.x + offsetX} ${
+  //     toPoint.y + offsetY
+  //   } L ${endArrow2X} ${endArrow2Y}`;
+  // }
 
   // Combine all parts of the path
-  path = `${startPath} ${path} ${endPath}`;
+  // path = `${startPath} ${path} ${endPath}`;
 
   return path;
 };
@@ -146,6 +148,7 @@ class XConnector extends Path {
       { x: 0, y: 0 },
       style
     );
+    console.log({ path });
     super(path, options);
     this.initialize();
     this.type = 'XConnector';
@@ -171,6 +174,7 @@ class XConnector extends Path {
       this,
       new Point(control2)
     );
+
     // if (!this.canvas) return;
     // let from = new Point(fromPoint).transform(this.canvas!.viewportTransform);
     // let to = new Point(toPoint).transform(this.canvas!.viewportTransform);
@@ -191,54 +195,55 @@ class XConnector extends Path {
 
     this.controls = {
       ...createObjectDefaultControls,
-      start: new Control({
-        x: 0,
-        y: 0,
-        offsetX: localFromPoint.x,
-        offsetY: localFromPoint.y,
-        mouseDownHandler: this._mouseDownControl.bind(this),
-        mouseUpHandler: this._mouseUpControl.bind(this),
-        positionHandler: this._positionControl.bind(this),
-        actionHandler: this.dragActionHandler.bind(this, 'start'),
-        cursorStyle: 'crosshair',
-        render: this._renderControl.bind(this, 'start'),
-      }),
-      end: new Control({
-        x: 0,
-        y: 0,
-        offsetX: localToPoint.x,
-        offsetY: localToPoint.y,
-        mouseDownHandler: this._mouseDownControl.bind(this),
-        mouseUpHandler: this._mouseUpControl.bind(this),
-        positionHandler: this._positionControl.bind(this),
-        actionHandler: this.dragActionHandler.bind(this, 'end'),
-        cursorStyle: 'crosshair',
-        render: this._renderControl.bind(this, 'end'),
-      }),
-      control1: new Control({
-        x: 0,
-        y: 0,
-        offsetX: localControl1.x,
-        offsetY: localControl1.y,
-        mouseDownHandler: this._mouseDownControl.bind(this),
-        mouseUpHandler: this._mouseUpControl.bind(this),
-        positionHandler: this._positionControl.bind(this),
-        actionHandler: this.dragActionHandler.bind(this, 'control1'),
-        cursorStyle: 'crosshair',
-        render: this._renderControl.bind(this, 'control1'),
-      }),
-      control2: new Control({
-        x: 0,
-        y: 0,
-        offsetX: localControl2.x,
-        offsetY: localControl2.y,
-        mouseDownHandler: this._mouseDownControl.bind(this),
-        mouseUpHandler: this._mouseUpControl.bind(this),
-        positionHandler: this._positionControl.bind(this),
-        actionHandler: this.dragActionHandler.bind(this, 'control2'),
-        cursorStyle: 'crosshair',
-        render: this._renderControl.bind(this, 'control2'),
-      }),
+      ...createPathControls(this),
+      // start: new Control({
+      //   x: 0,
+      //   y: 0,
+      //   offsetX: localFromPoint.x,
+      //   offsetY: localFromPoint.y,
+      //   mouseDownHandler: this._mouseDownControl.bind(this),
+      //   mouseUpHandler: this._mouseUpControl.bind(this),
+      //   positionHandler: this._positionControl.bind(this),
+      //   actionHandler: this.dragActionHandler.bind(this, 'start'),
+      //   cursorStyle: 'crosshair',
+      //   render: this._renderControl.bind(this, 'start'),
+      // }),
+      // end: new Control({
+      //   x: 0,
+      //   y: 0,
+      //   offsetX: localToPoint.x,
+      //   offsetY: localToPoint.y,
+      //   mouseDownHandler: this._mouseDownControl.bind(this),
+      //   mouseUpHandler: this._mouseUpControl.bind(this),
+      //   positionHandler: this._positionControl.bind(this),
+      //   actionHandler: this.dragActionHandler.bind(this, 'end'),
+      //   cursorStyle: 'crosshair',
+      //   render: this._renderControl.bind(this, 'end'),
+      // }),
+      // control1: new Control({
+      //   x: 0,
+      //   y: 0,
+      //   offsetX: localControl1.x,
+      //   offsetY: localControl1.y,
+      //   mouseDownHandler: this._mouseDownControl.bind(this),
+      //   mouseUpHandler: this._mouseUpControl.bind(this),
+      //   positionHandler: this._positionControl.bind(this),
+      //   actionHandler: this.dragActionHandler.bind(this, 'control1'),
+      //   cursorStyle: 'crosshair',
+      //   render: this._renderControl.bind(this, 'control1'),
+      // }),
+      // control2: new Control({
+      //   x: 0,
+      //   y: 0,
+      //   offsetX: localControl2.x,
+      //   offsetY: localControl2.y,
+      //   mouseDownHandler: this._mouseDownControl.bind(this),
+      //   mouseUpHandler: this._mouseUpControl.bind(this),
+      //   positionHandler: this._positionControl.bind(this),
+      //   actionHandler: this.dragActionHandler.bind(this, 'control2'),
+      //   cursorStyle: 'crosshair',
+      //   render: this._renderControl.bind(this, 'control2'),
+      // }),
     };
   }
 
@@ -723,25 +728,12 @@ export { XConnector };
 export const TransformPointFromObjectToCanvas = (
   object: FabricObject,
   point: Point
-) => {
-  const mObject = object.calcOwnMatrix();
-  // const mCanvas = object.getViewportTransform();
-  // const matrix = multiplyTransformMatrices(mCanvas, mObject);
-  const transformedPoint = point.transform(mObject); // transformPoint(point, matrix);
-  return transformedPoint;
-};
+) => sendPointToPlane(point, object.calcOwnMatrix(), iMatrix);
 
 export const TransformPointFromCanvasToObject = (
   object: FabricObject,
   point: Point
-) => {
-  const mObject = object.calcOwnMatrix();
-  // const mCanvas = object.canvas!.viewportTransform;
-  // const matrix = multiplyTransformMatrices(mCanvas, mObject);
-  const invertedMatrix = invertTransform(mObject);
-  const transformedPoint = point.transform(invertedMatrix);
-  return transformedPoint;
-};
+) => sendPointToPlane(point, iMatrix, object.calcOwnMatrix());
 
 export const TransformPointFromObjectToCanvas2 = (
   object: FabricObject,

--- a/src/shapes/canvasx/XConnector.ts
+++ b/src/shapes/canvasx/XConnector.ts
@@ -72,10 +72,10 @@ class XConnector extends Path {
         mouseDownHandler: this._mouseDownControl.bind(this),
         mouseUpHandler: this._mouseUpControl.bind(this),
         cursorStyle: 'crosshair',
-        cpOverrides: {
-          cornerColor: 'blue',
-          cornerDashArray: [5, 5],
-          cornerStrokeColor: 'gray',
+        controlPointStyle: {
+          controlFill: 'blue',
+          connectionDashArray: [5, 5],
+          controlStroke: 'gray',
         },
       }),
     };

--- a/src/shapes/canvasx/XConnector.ts
+++ b/src/shapes/canvasx/XConnector.ts
@@ -279,44 +279,20 @@ class XConnector extends Path {
 
       const targetX = hoverPoint.x;
       const targetY = hoverPoint.y;
-      const controlPoint = currentDockingObject.calculateControlPoint(
-        currentDockingObject.getBoundingRect(),
-        new Point(targetX, targetY)
-      );
-      const relevantControlPoint = target
-        .transformPointFromCanvas(controlPoint)
-        .add(this.pathOffset);
 
-      switch (commandIndex) {
-        // command 0 means start of the path
-        case 0:
-          if (target.fromId) {
-            const fromObject = target.canvas?.findById(target.fromId);
-            if (fromObject) {
-              fromObject.connectors = fromObject.connectors?.filter(
-                (connector: any) => connector.connectorId !== target.id
-              );
-            }
-          }
-          // register docking of this object
-          target.fromId = currentDockingObject.id;
+      const property = commandIndex === 0 ? 'fromId' : 'toId';
+      const existingConnectionId = target[property];
 
-          break;
-        case this.path.length - 1:
-          if (target.toId) {
-            const toObject = target.canvas?.findById(target.toId);
-            if (toObject) {
-              const newConnectors = toObject.connectors?.filter(
-                (connector: any) => connector.connectorId !== target.id
-              );
-              toObject.connectors = newConnectors;
-            }
-          }
-          // register docking of this object
-          target.toId = currentDockingObject.id;
-
-          break;
+      if (existingConnectionId) {
+        const connectedObject = target.canvas?.findById(existingConnectionId);
+        if (connectedObject) {
+          connectedObject.connectors = connectedObject.connectors?.filter(
+            (connector: any) => connector.connectorId !== target.id
+          );
+        }
       }
+
+      target[commandIndex === 0 ? 'fromId' : 'toId'] = currentDockingObject.id;
 
       if (!currentDockingObject.connectors) {
         currentDockingObject.connectors = [];

--- a/src/shapes/canvasx/XConnector.ts
+++ b/src/shapes/canvasx/XConnector.ts
@@ -270,8 +270,6 @@ class XConnector extends Path {
     // and removed when we start the connector drag.
     // this logic should be resolved inside the connector.
 
-    // early return if we are dragging a control point
-
     if (
       currentDockingObject &&
       currentDockingObject.controls[currentDockingObject.hoveringControl] &&

--- a/src/shapes/canvasx/XConnector.ts
+++ b/src/shapes/canvasx/XConnector.ts
@@ -5,7 +5,6 @@ import {
   TSimpleParsedCommand,
 } from '../../util';
 import { Point, XY } from '../../Point';
-import { TMat2D } from '../../typedefs';
 import { createObjectDefaultControls } from '../../controls/commonControls';
 import { FabricObject } from '../Object/Object';
 import { Transform } from '../../EventTypeDefs';
@@ -13,6 +12,7 @@ import { classRegistry } from '../../ClassRegistry';
 import { iMatrix } from '../../constants';
 import { createPathControls } from '../../controls/pathControl';
 import { makePathSimpler, parsePath } from '../../util/path';
+
 const getPath = (
   fromPoint: XY,
   toPoint: XY,
@@ -31,12 +31,8 @@ class XConnector extends Path {
   static type = 'XConnector';
   objType = 'Xconnector';
   style: any;
-  prevLeft: number;
-  prevTop: number;
-  preCenter: Point;
-  preTransform: TMat2D | null;
-  fromObjectId: string;
-  toObjectId: string;
+  declare fromObjectId: string;
+  declare toObjectId: string;
   declare pathType: 'curvePath' | 'straightPath';
   declare pathArrowTip: 'none' | 'start' | 'end' | 'both';
 

--- a/src/shapes/canvasx/XConnector.ts
+++ b/src/shapes/canvasx/XConnector.ts
@@ -177,14 +177,14 @@ class XConnector extends Path {
     if (!control1) {
       control1 = TransformPointFromObjectToCanvas(
         this,
-        new Point(finalCommand[3]!, finalCommand[4]!)
+        new Point(finalCommand[1]!, finalCommand[2]!)
       );
     }
 
     if (!control2) {
       control2 = TransformPointFromObjectToCanvas(
         this,
-        new Point(finalCommand[5]!, finalCommand[6]!)
+        new Point(finalCommand[3]!, finalCommand[4]!)
       );
     }
 

--- a/src/shapes/canvasx/XObject.ts
+++ b/src/shapes/canvasx/XObject.ts
@@ -32,7 +32,7 @@ export class FabricObject2 {
   // activeSelectWithoutArrow: any[] = [];
   // activeSelectionWithArrow: any[] = [];
 
-  transformPointToCanvas(point: XY) {
+  transformPointToCanvas(point: XY): Point {
     const self = this;
     const toTransformPoint = new Point(point);
     const transformedPoint = toTransformPoint.transform(
@@ -40,7 +40,8 @@ export class FabricObject2 {
     );
     return transformedPoint;
   }
-  transformPointFromCanvas(point: XY) {
+
+  transformPointFromCanvas(point: XY): Point {
     const self = this;
     const toTransformPoint = new Point(point);
     const transformedPoint = toTransformPoint.transform(

--- a/src/util/path/typedefs.ts
+++ b/src/util/path/typedefs.ts
@@ -294,6 +294,8 @@ export type TSimpleParsedCommand =
   | TParsedAbsoluteCubicCurveCommand
   | TParsedAbsoluteQuadraticCurveCommand;
 
+export type TSimpleParseCommandType = 'L' | 'M' | 'C' | 'Q' | 'Z';
+
 /**
  * A series of simple paths
  */


### PR DESCRIPTION
## Description

Before patching just the bounding box and consolidate the current logic i want to see if i can remove the extra code from the XConnector class and leverage the fabricJS pathControl utility.

## In Action

<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->

<img width="337" alt="image" src="https://github.com/user-attachments/assets/af5a7685-7353-4b3c-a718-5a9386a9e6c9">

I m having issue with the color of the first control point, but apart from that seems that replicates the original functionalities and is refactored to be a bit more concise and to leverage fabricJS features
