### PR TITLE
Proposal(): Remove from XConnectors properties that are duplicate of other state

### DIFF
--- a/src/shapes/Path.ts
+++ b/src/shapes/Path.ts
@@ -65,8 +65,9 @@ export class Path<
   declare segmentsInfo?: TPathSegmentInfo[];
 
   static type = 'Path';
-  fromObjectId: string;
-  toObjectId: string;
+  // ?
+  // fromObjectId: string;
+  // toObjectId: string;
 
   static cacheProperties = [...cacheProperties, 'path', 'fillRule'];
 

--- a/src/shapes/canvasx/XConnector.ts
+++ b/src/shapes/canvasx/XConnector.ts
@@ -1,11 +1,12 @@
-import { Path } from '../Path';
+import { Path, PathProps, SerializedPathProps } from '../Path';
 import { sendPointToPlane, TSimpleParsedCommand } from '../../util';
 import { Point, XY } from '../../Point';
-import { Transform } from '../../EventTypeDefs';
+import { ObjectEvents, Transform } from '../../EventTypeDefs';
 import { classRegistry } from '../../ClassRegistry';
 import { iMatrix } from '../../constants';
 import { createPathControls } from '../../controls/pathControl';
 import { XCanvas } from '../../canvas/canvasx/bx-canvas';
+import { TClassProperties, TOptions } from '../../typedefs';
 
 const getPath = (
   fromPoint: XY,
@@ -21,18 +22,46 @@ const getPath = (
   }
 };
 
-class XConnector extends Path {
-  static type = 'XConnector';
-  objType = 'XConnector';
+interface UniqueXConnectorProps {
+  fromObjectId?: string;
+  toObjectId?: string;
+  fromPoint: XY;
+  toPoint: XY;
+  control1: XY;
+  control2: XY;
+  pathType: 'curvePath' | 'straightPath';
+  pathArrowTip: 'none' | 'start' | 'end' | 'both';
   style: any;
-  declare fromObjectId: string;
-  declare toObjectId: string;
+}
+
+export interface XConnectorProps extends PathProps, UniqueXConnectorProps {}
+
+export interface XConnectorSerializedProps
+  extends SerializedPathProps,
+    UniqueXConnectorProps {}
+
+class XConnector<
+  Props extends TOptions<XConnectorProps> = Partial<XConnectorProps>,
+  SProps extends XConnectorSerializedProps = XConnectorSerializedProps,
+  EventSpec extends ObjectEvents = ObjectEvents
+> extends Path<Props, SProps, EventSpec> {
+  static type = 'XConnector';
+  declare objType: string;
+  declare style: any;
+
+  /**
+   * References the ID of the object where the connector starts
+   */
+  private declare fromObjectId: string;
+
+  /**
+   * References the ID of the object where the connector ends
+   */
+  private declare toObjectId: string;
+
   declare pathType: 'curvePath' | 'straightPath';
+
   declare pathArrowTip: 'none' | 'start' | 'end' | 'both';
-  declare fromPoint: XY;
-  declare toPoint: XY;
-  declare control1: XY;
-  declare control2: XY;
 
   /**
    * Contains the path to draw the arrow tip start
@@ -55,18 +84,14 @@ class XConnector extends Path {
     'zIndex',
     'fromObjectId',
     'toObjectId',
-    'control1',
-    'control2',
     'style',
     'pathType',
     'pathArrowTip',
-    'fromPoint',
-    'toPoint',
     'left',
     'top',
     'width',
     'height',
-  ];
+  ] as const as (keyof SProps)[];
 
   constructor(
     fromPoint: XY,
@@ -77,25 +102,22 @@ class XConnector extends Path {
     options: any = {}
   ) {
     const path = getPath(fromPoint, toPoint, control1, control2);
-    super(path, options);
+    super(path);
     this.cornerColor = 'white';
     this.cornerStyle = 'circle';
     this.transparentCorners = false;
     this.cornerStrokeColor = 'gray';
+    this.setOptions(options);
+    // this shouldn't work
     this.type = 'XConnector';
+    this.objType = 'XConnector';
     this.objectCaching = false;
     this.pathType = options.pathType || 'curvePath';
     this.pathArrowTip = options.pathArrowTip || 'both';
-    this.fromObjectId = options.fromObjectId;
-    this.toObjectId = options.toObjectId;
-    this.fromPoint = fromPoint;
-    this.toPoint = toPoint;
-    this.control1 = control1;
-    this.control2 = control2;
     this.style = style;
     this.calcStartEndPath();
     this.controls = {
-      ...createPathControls(this, {
+      ...createPathControls(this as Path, {
         mouseDownHandler: this._mouseDownControl.bind(this),
         mouseUpHandler: this._mouseUpControl.bind(this),
         cursorStyle: 'crosshair',
@@ -203,7 +225,6 @@ class XConnector extends Path {
         this,
         new Point(finalCommand[1]!, finalCommand[2]!)
       );
-      this.control1 = control1;
     }
 
     if (!control2) {
@@ -211,7 +232,6 @@ class XConnector extends Path {
         this,
         new Point(finalCommand[3]!, finalCommand[4]!)
       );
-      this.control2 = control2;
     }
 
     if (!fromPoint) {
@@ -219,7 +239,6 @@ class XConnector extends Path {
         this,
         new Point(this.path[0][1]!, this.path[0][2]!)
       );
-      this.fromPoint = fromPoint;
     }
 
     if (!toPoint) {
@@ -230,7 +249,6 @@ class XConnector extends Path {
           : new Point(finalCommand[5]!, finalCommand[6]!)
       );
       finalCommand[0] === 'L' ? 1 : 5;
-      this.toPoint = toPoint;
     }
 
     if (style) {
@@ -351,12 +369,45 @@ class XConnector extends Path {
       });
     }
   }
+
+  /**
+   * Returns object representation of an instance
+   * @param {Array} [propertiesToInclude] Any properties that you might want to additionally include in the output
+   * @return {Object} object representation of an instance
+   */
+  toObject<
+    T extends Omit<Props & TClassProperties<this>, keyof SProps>,
+    K extends keyof T = never
+  >(this: XConnector, propertiesToInclude: K[] = []): Pick<T, K> & SProps {
+    return {
+      ...super.toObject<T, K>([
+        ...propertiesToInclude,
+        ...(this.extendedProperties as K[]),
+      ]),
+      fromPoint: TransformPointFromPathToCanvas(
+        this,
+        new Point(this.path[0][1]!, this.path[0][2]!)
+      ),
+      control1: TransformPointFromPathToCanvas(
+        this,
+        new Point(this.path[1][1]!, this.path[1][2]!)
+      ),
+      control2: TransformPointFromPathToCanvas(
+        this,
+        new Point(this.path[1][3]!, this.path[1][4]!)
+      ),
+      toPoint: TransformPointFromPathToCanvas(
+        this,
+        new Point(this.path[1][5]!, this.path[1][6]!)
+      ),
+    };
+  }
 }
 
 export { XConnector };
 
 export const TransformPointFromPathToCanvas = (
-  object: XConnector,
+  object: XConnector<any, any>,
   point: Point
 ) =>
   sendPointToPlane(


### PR DESCRIPTION


## Description

This is up for discussion and debate.
I ll try to be more clear in the comments near the code, but in few words fromPoint, toPoint, control1, control2 are non functional copies of the data array of the path, that we store and keep updated for later export.

The issue with that is that a developer could think those properties do actually something, while changing them has no effect.
I think is safer to keep the object serialized representation in toObject and the constructor ( or even better fromObject would be the correct way imho, but i don't want to go in arguments over code that have no practical difference )